### PR TITLE
Fixing Go Based Installations

### DIFF
--- a/Shell/.pathVars
+++ b/Shell/.pathVars
@@ -5,8 +5,8 @@
 # Use: Add additional paths to PATH by defining them here and they will be sourced by .zshrc
 
 # set PATH so it includes user's private ~/.local/bin if it exists
-if [[ -d "${HOME}/.local/bin" ]] ; then
-    PATH="${HOME}/.local/bin:${PATH}"
+if [[ -d "${HOME}/.local/bin" ]] && [[ ":$PATH:" != *":${HOME}/.local/bin:"* ]]; then
+  PATH="${HOME}/.local/bin:${PATH}"
 fi
 
 # If OS is Mac add Homebrew to PATH
@@ -24,31 +24,31 @@ if [[ ${OS} == "Mac" ]] && which pyenv-virtualenv-init > /dev/null; then
 fi
 
 # If go/golang is installed add to PATH
-if [[ -d "${HOME}/go" ]]; then
+if [[ -d "${HOME}/go" ]] && [[ ":$PATH:" != *":${HOME}/go/bin:"* ]]; then
   export PATH="${PATH}:${HOME}/go/bin"
 fi
 
 # If rust is installed add cargo to PATH
-if [[ -d "${HOME}/.cargo/bin" ]]; then
+if [[ -d "${HOME}/.cargo/bin" ]] && [[ ":$PATH:" != *":${HOME}/.cargo/bin:"* ]]; then
   export PATH="${PATH}:${HOME}/.cargo/bin"
 fi
 
 # If tfenv is installed (by testing for the tfenv command) add to PATH
-if command -v tfenv 1>/dev/null 2>&1; then
+if command -v tfenv 1>/dev/null 2>&1 && [[ ":$PATH:" != *":${HOME}/.tfenv/bin:"* ]]; then
   export PATH="${HOME}/.tfenv/bin:${PATH}"
 fi
 
 # If pkenv is installed (by testing for the pkenv command) add to PATH
-if command -v pkenv 1>/dev/null 2>&1; then
+if command -v pkenv 1>/dev/null 2>&1 && [[ ":$PATH:" != *":${HOME}/.pkenv/bin:"* ]]; then
   export PATH="${HOME}/.pkenv/bin:${PATH}"
 fi
 
 # If kubectl is installed add to PATH
-if command -v kubectl 1>/dev/null 2>&1; then
+if command -v kubectl 1>/dev/null 2>&1 && [[ ":$PATH:" != *":${HOME}/.kube:"* ]]; then
   export PATH="${PATH}:${HOME}/.kube"
 fi
 
 # If helm is installed add to PATH
-if command -v helm 1>/dev/null 2>&1; then
+if command -v helm 1>/dev/null 2>&1 && [[ ":$PATH:" != *":${HOME}/.helm:"* ]]; then
   export PATH="${PATH}:${HOME}/.helm"
 fi

--- a/Shell/.pathVars
+++ b/Shell/.pathVars
@@ -10,15 +10,9 @@ if [[ -d "${HOME}/.local/bin" ]] ; then
 fi
 
 # If OS is Mac add Homebrew to PATH
-# If OS is Mac then load the apple keychain for SSH
 if [[ ${OS} == "Mac" ]]; then
 	eval "$(/opt/homebrew/bin/brew shellenv)"
 fi
-
-# # Add Cargo to PATH
-# if command -v cargo &> /dev/null; then
-#   export PATH="$HOME/.cargo/bin:$PATH"
-# fi
 
 # If OS is Mac and pyenv is installed initialise pyenv
 if [[ ${OS} == "Mac" ]] && command -v pyenv 1>/dev/null 2>&1; then
@@ -37,4 +31,24 @@ fi
 # If rust is installed add cargo to PATH
 if [[ -d "${HOME}/.cargo/bin" ]]; then
   export PATH="${PATH}:${HOME}/.cargo/bin"
+fi
+
+# If tfenv is installed (by testing for the tfenv command) add to PATH
+if command -v tfenv 1>/dev/null 2>&1; then
+  export PATH="${HOME}/.tfenv/bin:${PATH}"
+fi
+
+# If pkenv is installed (by testing for the pkenv command) add to PATH
+if command -v pkenv 1>/dev/null 2>&1; then
+  export PATH="${HOME}/.pkenv/bin:${PATH}"
+fi
+
+# If kubectl is installed add to PATH
+if command -v kubectl 1>/dev/null 2>&1; then
+  export PATH="${PATH}:${HOME}/.kube"
+fi
+
+# If helm is installed add to PATH
+if command -v helm 1>/dev/null 2>&1; then
+  export PATH="${PATH}:${HOME}/.helm"
 fi

--- a/Shell/.zsh_profile
+++ b/Shell/.zsh_profile
@@ -6,7 +6,13 @@
 
 # shellcheck source=/dev/null
 
-PATH="${HOME}/.local/bin:${HOME}/bin:${PATH}"
+if [[ ! ":$PATH:" == *":${HOME}/.local/bin:"* ]]; then
+  PATH="${HOME}/.local/bin:${PATH}"
+fi
+
+if [[ ! ":$PATH:" == *":${HOME}/bin:"* ]]; then
+  PATH="${HOME}/bin:${PATH}"
+fi
 
 # Test if we have oh-my-posh, or oh-my-zsh installed and if so load them.  If we have both preference is given to oh-my-posh such that priority order is oh-my-posh, oh-my-zsh, default zsh profile/prompt configuration
 if command -v oh-my-posh &> /dev/null; then

--- a/Shell/applets/ansible.applets
+++ b/Shell/applets/ansible.applets
@@ -9,7 +9,7 @@
 # Define additional functions here
 
 # Install ansible using pip3 after confirming that the latest version is not already installed
-ansible-install () {
+ansible_install () {
   # Check the latest available version of Ansible by grepping the "version" field from the JSON output of the PyPi API
   PYPI_ANSIBLE_VERSION=$(curl -s https://pypi.org/pypi/ansible/json | grep -Eo '"version":"[0-9]+\.[0-9]+\.[0-9]+",' | sed -E 's/.+"([0-9]+\.[0-9]+\.[0-9]+)",/\1/')
   # PYPI_ANSIBLE_CORE=$(curl -s https://pypi.org/pypi/ansible/json | grep -Eo '\[\"ansible-core.*\"],' | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')

--- a/Shell/applets/aws.applets
+++ b/Shell/applets/aws.applets
@@ -38,6 +38,11 @@ aws_update () {
 # Update AWS CLI on Linux
 aws_update_linux () {
   echo "[INFO] Downloading AWS CLI"
+  # If the command unzip is not available then return an error - required for the install
+  if ! command -v unzip &> /dev/null; then
+    echo "[ERROR] Unzip is not installed"
+    return 1
+  fi
   cd /tmp || return
   curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
   echo "[INFO] AWS CLI downloaded"

--- a/Shell/applets/aws.applets
+++ b/Shell/applets/aws.applets
@@ -40,7 +40,7 @@ aws_update_linux () {
   echo "[INFO] Downloading AWS CLI"
   # If the command unzip is not available then return an error - required for the install
   if ! command -v unzip &> /dev/null; then
-    echo "[ERROR] Unzip is not installed"
+    echo "[ERROR] Unzip is not installed - required for AWS CLI install"
     return 1
   fi
   cd /tmp || return

--- a/Shell/applets/aws.applets
+++ b/Shell/applets/aws.applets
@@ -9,9 +9,9 @@
 # Define additional functions here
 
 # Update AWS CLI
-aws-update () {
+aws_update () {
   # Check if user has sudo access using provided function and exit if not
-  if ! sudo-test; then
+  if ! sudo_test; then
     echo "[ERROR] Cannot update AWS CLI - user does not have sudo access"
     return 1
   fi
@@ -22,12 +22,12 @@ aws-update () {
   fi
   # If the OS is Linux then run the Linux function
   if [[ "${OS}" == "Linux" ]]; then
-    aws-update-linux
+    aws_update_linux
     return 0
   fi
   # If the OS is Mac then run the Mac function
   if [[ "${OS}" == "Mac" ]]; then
-    aws-update-mac
+    aws_update_mac
     return 0
   fi
   # If the OS is not Linux or Mac then report an error - will only get here if OS is not set
@@ -36,7 +36,7 @@ aws-update () {
 }
 
 # Update AWS CLI on Linux
-aws-update-linux () {
+aws_update_linux () {
   echo "[INFO] Downloading AWS CLI"
   cd /tmp || return
   curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
@@ -65,7 +65,7 @@ aws-update-linux () {
 }
 
 # Update AWS CLI on Mac
-aws-update-mac () {
+aws_update_mac () {
   echo "[INFO] Downloading AWS CLI"
   cd /tmp || return
   curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"

--- a/Shell/applets/general.applets
+++ b/Shell/applets/general.applets
@@ -19,7 +19,7 @@ show_ssh_tunnel(){
 }
 
 # Test sudo access
-sudo-test (){
+sudo_test (){
   if [[ ! $(sudo -l -U "${USER}") ]]; then
     echo "[ERROR] User does not have sudo access"
     return 1
@@ -32,15 +32,25 @@ sudo-test (){
 update_tools () {
   echo "== Updating Tools =="
   echo "== Updating AWS CLI =="
-  aws-update
+  aws_update
   echo "== Updating Kubectl =="
-  echo "[INFO] Updating Kubectl to latest version - using set-kubectl -v <version> to set a specific version"
-  set-kubectl -s
+  echo "[INFO] Updating Kubectl to latest version - using set_kubectl -v <version> to set a specific version"
+  set_kubectl -s
   echo "== Installing Helm =="
-  helm-install
+  helm_install
   echo "== Updating Terraform =="
-  terraform-install
+  terraform_install
   echo "== Updating Ansible =="
-  ansible-install
+  ansible_install
   return 0
+}
+
+# Get the version of GO if installed and save it to an envrioment variable
+get_go_version () {
+  if [[ -x "$(command -v go)" ]]; then
+    export GO_VERSION=$(go version | awk '{print $3}'| tr -d 'go')
+  else
+    echo "[ERROR] GO is not installed"
+    return 1
+  fi
 }

--- a/Shell/applets/k8s.applets
+++ b/Shell/applets/k8s.applets
@@ -9,7 +9,7 @@
 # Define additional functions here
 
 # Function to set a specific version of kubectl for the current shell and if it is not already installed download it
-set-kubectl () {
+set_kubectl () {
   # Check if variables are already set and if so unset -f
   if [[ -v KUBECTL_VERSION ]]; then
     KUBECTL_VERSION=""
@@ -20,7 +20,7 @@ set-kubectl () {
   # Use getopts to parse the arguments
   while getopts ":hlsv:" opt; do
     case $opt in
-      h) echo "Usage: set-kubectl [-v version]"
+      h) echo "Usage: set_kubectl [-v version]"
          echo "  -v version  The version of kubectl to use"
          return 0
       ;;
@@ -123,7 +123,7 @@ set-kubectl () {
   return 0
 }
 
-helm-install () {
+helm_install () {
   # Install and update helm
   # Check if the ${OS} variable is set and if not report an error and exit
   if [[ -z "${OS}" ]]; then
@@ -146,16 +146,16 @@ helm-install () {
   fi
   # Check if the OS is Linux or Mac and if so call the relevant function
   if [[ "${OS}" == "Linux" ]]; then
-    helm-linux-install "${HELM_VERSION}"
+    helm_install_linux "${HELM_VERSION}"
   elif [[ "${OS}" == "Mac" ]]; then
-    helm-mac-install "${HELM_VERSION}"
+    helm_install_mac "${HELM_VERSION}"
   else
     echo "[ERROR] Unsupported OS"
     return 1
   fi
 }
 
-helm-linux-install () {
+helm_install_linux () {
   # Install and update helm for Linux referencing: https://helm.sh/docs/intro/install/
   # Using the script mechanism to make this easier to support across distros
   # Accept a passed variable for the HELM_VERSION from the calling function
@@ -202,7 +202,7 @@ helm-linux-install () {
   cd - || return 1
 }
 
-helm-mac-install () {
+helm_install_mac () {
   # Install and update helm for Mac referencing: https://helm.sh/docs/intro/install/
   # Accept a passed variable for the HELM_VERSION from the calling function
   HELM_VERSION="${1}"

--- a/Shell/applets/terraform.applets
+++ b/Shell/applets/terraform.applets
@@ -62,7 +62,7 @@ tf_install_linux () {
   # Add the tfenv bin directory to the PATH if it is not already there
   if ! echo "${PATH}" | grep -q "${HOME}/.tfenv/bin"; then
     echo "[INFO] Adding ${HOME}/.tfenv/bin to PATH"
-    echo 'export PATH="$HOME/.tfenv/bin:$PATH"'
+    export PATH="$HOME/.tfenv/bin:$PATH"
   fi
   # If the tfenv command is not available after adding the bin directory to the PATH then report an error and exit
   if ! command -v tfenv &> /dev/null; then

--- a/Shell/applets/terraform.applets
+++ b/Shell/applets/terraform.applets
@@ -60,10 +60,10 @@ tf_install_linux () {
     return 1
   fi
   # If the default tfenv bin directory is not in the PATH then add it to PATH directly
-  if ! echo "${PATH}" | grep -q "${HOME}/.tfenv/bin"; then
+  if [[ ! ":$PATH:" == *":${HOME}/.tfenv/bin:"* ]]; then
     echo "[INFO] Adding ${HOME}/.tfenv/bin to PATH"
-    export PATH="${HOME}/.tfenv/bin:${PATH}"
-  fi  
+    PATH="${HOME}/.tfenv/bin:${PATH}"
+  fi
   # If the tfenv command is not available after adding the bin directory to the PATH then report an error and exit
   if ! command -v tfenv &> /dev/null; then
     echo "[ERROR] tfenv not found"

--- a/Shell/applets/terraform.applets
+++ b/Shell/applets/terraform.applets
@@ -59,10 +59,10 @@ tf_install_linux () {
     echo "[ERROR] Error installing tfenv"
     return 1
   fi
-  # Add the tfenv bin directory to the PATH by sourcing the .pathVars file if it is not already in the PATH
+  # Add the tfenv bin directory to the PATH if it is not already there
   if ! echo "${PATH}" | grep -q "${HOME}/.tfenv/bin"; then
     echo "[INFO] Adding ${HOME}/.tfenv/bin to PATH"
-    source "${HOME}/.pathVars"
+    echo 'export PATH="$HOME/.tfenv/bin:$PATH"'
   fi
   # If the tfenv command is not available after adding the bin directory to the PATH then report an error and exit
   if ! command -v tfenv &> /dev/null; then
@@ -394,31 +394,6 @@ terraform_docs_install_mac () {
     if [[ "$(terraform-docs --version | sed -r 's/v([0-9]\.[0-9]+\.[0-9]+)/\1/')" == "${TERRAFORM_DOCS_VERSION}" ]]; then
       echo "[INFO] terraform-docs ${TERRAFORM_DOCS_VERSION} is already installed and is the latest version"
       return 0
-    fi
-  fi
-  echo "[INFO] terraform-docs is not installed or is not the correct version.  Installing terraform-docs v${TERRAFORM_DOCS_VERSION}"
-  # Use Homebrew to install terraform-docs
-  # Check if Homebrew is installed and if not report an error
-  if ! command -v brew &> /dev/null; then
-    echo "[ERROR] Homebrew is not installed.  Please install Homebrew and try again"
-    return 1
-  fi
-  # Check if terraform-docs is already installed, if not install it, if it is then upgrade it
-  if command -v terraform-docs &> /dev/null; then
-    echo "[INFO] Upgrading terraform-docs"
-    brew upgrade terraform-docs
-  else
-    echo "[INFO] Installing terraform-docs"
-    brew install terraform-docs
-  fi
-  # Check if terraform-docs is installed and if not report an error
-  if ! command -v terraform-docs &> /dev/null; then
-    echo "[ERROR] Error installing terraform-docs"
-    echo "[ERROR] Please check the version is valid and try again"
-    return 1
-  fi
-  echo "[INFO] terraform-docs ${TERRAFORM_DOCS_VERSION} installed"
-}     return 0
     fi
   fi
   echo "[INFO] terraform-docs is not installed or is not the correct version.  Installing terraform-docs v${TERRAFORM_DOCS_VERSION}"

--- a/Shell/applets/terraform.applets
+++ b/Shell/applets/terraform.applets
@@ -65,6 +65,11 @@ tf_install_linux () {
     echo "[ERROR] Unsupported OS"
     return 1
   fi
+  # If the command unzip is not available then return an error - required for the install
+  if ! command -v unzip &> /dev/null; then
+    echo "[ERROR] Unzip is not installed"
+    return 1
+  fi
   # Check if the requested version is available in the directory and if not download it
   if [[ ! -f "${TF_DIR}/terraform" ]]; then
     echo "[INFO] Downloading Terraform-${TF_VERSION}"
@@ -122,6 +127,11 @@ tf_install_mac () {
     TF_URL="https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_darwin_amd64.zip"
   else
     echo "[ERROR] Unsupported OS"
+    return 1
+  fi
+  # If the command unzip is not available then return an error - required for the install
+  if ! command -v unzip &> /dev/null; then
+    echo "[ERROR] Unzip is not installed"
     return 1
   fi
   # Check if the requested version is available in the directory and if not download it
@@ -288,9 +298,9 @@ tfsec_install_linux () {
   GO_MINOR_VERSION=$(echo "${GO_VERSION}" | cut -d. -f2)
   # If the combined major and minor version of Go is less than or equal to 1.17 then use the old method of installing tfsec with go get and if it is greater than 1.17 then use the new method of installing tfsec with go install
   if [[ "${GO_MAJOR_VERSION}${GO_MINOR_VERSION}" -le 117 ]]; then
-    go get github.com/aquasecurity/tfsec/cmd/tfsec@latest
+    go get github.com/aquasecurity/tfsec/cmd/tfsec@latest > /dev/null
   else
-    go install github.com/aquasecurity/tfsec/cmd/tfsec@latest
+    go install github.com/aquasecurity/tfsec/cmd/tfsec@latest > /dev/null
   fi
   # Check if the version installed is the correct version and if not report an error
   if [[ "$(tfsec --version | sed -r 's/tfsec version ([0-9]\.[0-9]+\.[0-9]+)/\1/' | grep -E -m 1 '[0-9]\.[0-9]+\.[0-9]+')" != "${TFSEC_VERSION}" ]]; then
@@ -377,9 +387,9 @@ terraform_docs_install_linux () {
   GO_MINOR_VERSION=$(echo "${GO_VERSION}" | cut -d. -f2)
   # If the combined major and minor version of Go is less than or equal to 1.17 then use the old method of installing terraform-docs with go get and if it is greater than 1.17 then use the new method of installing terraform-docs with go install
   if [[ "${GO_MAJOR_VERSION}${GO_MINOR_VERSION}" -le 117 ]]; then
-    go get github.com/terraform-docs/terraform-docs/cmd/terraform-docs@latest
+    go get github.com/terraform-docs/terraform-docs/cmd/terraform-docs@latest > /dev/null
   else
-    go install github.com/terraform-docs/terraform-docs/cmd/terraform-docs@latest
+    go install github.com/terraform-docs/terraform-docs/cmd/terraform-docs@latest > /dev/null
   fi
   # Check if the version installed is the correct version and if not report an error
   if [[ "$(terraform-docs --version | sed -r 's/v([0-9]\.[0-9]+\.[0-9]+)/\1/')" != "${TERRAFORM_DOCS_VERSION}" ]]; then

--- a/Shell/applets/terraform.applets
+++ b/Shell/applets/terraform.applets
@@ -59,14 +59,14 @@ tf_install_linux () {
     echo "[ERROR] Error installing tfenv"
     return 1
   fi
-  # Add the tfenv bin directory to the PATH if it is not already there
+  # If the default tfenv bin directory is not in the PATH then add it to PATH directly
   if ! echo "${PATH}" | grep -q "${HOME}/.tfenv/bin"; then
     echo "[INFO] Adding ${HOME}/.tfenv/bin to PATH"
-    export PATH="$HOME/.tfenv/bin:$PATH"
-  fi
+    export PATH="${HOME}/.tfenv/bin:${PATH}"
+  fi  
   # If the tfenv command is not available after adding the bin directory to the PATH then report an error and exit
   if ! command -v tfenv &> /dev/null; then
-    echo "[ERROR] Error installing tfenv"
+    echo "[ERROR] tfenv not found"
     return 1
   fi
   # If the tfenv command is available then install the latest version of Terraform

--- a/Shell/applets/terraform.applets
+++ b/Shell/applets/terraform.applets
@@ -247,10 +247,13 @@ tfsec_install_linux () {
   fi
   # Check if tfsec is already installed and if the current version matches the version to be set
   if command -v tfsec &> /dev/null; then
-    if [[ "$(tfsec --version | sed -r 's/tfsec version ([0-9]\.[0-9]+\.[0-9]+)/\1/' | grep -E -m 1 '[0-9]\.[0-9]+\.[0-9]+')" == "${TFSEC_VERSION}" ]]; then
-      echo "[INFO] tfsec ${TFSEC_VERSION} is already installed and is the latest version"
-      return 0
-    fi
+    # With changes to tfsec moving to trivy this check doesn't work as expected and will need to be updated
+    # if [[ "$(tfsec --version | sed -r 's/tfsec version ([0-9]\.[0-9]+\.[0-9]+)/\1/' | grep -E -m 1 '[0-9]\.[0-9]+\.[0-9]+')" == "${TFSEC_VERSION}" ]]; then
+    #   echo "[INFO] tfsec ${TFSEC_VERSION} is already installed and is the latest version"
+    #   return 0
+    # fi
+    echo "[INFO] tfsec is already installed"
+    return 0
   fi
   echo "[INFO] tfsec is not installed or is not the correct version.  Installing tfsec v${TFSEC_VERSION}"
   # Install tfsec using Go
@@ -273,11 +276,12 @@ tfsec_install_linux () {
     PATH="${HOME}/go/bin:${PATH}"
   fi
   # Check if the version installed is the correct version and if not report an error
-  if [[ "$(tfsec --version | sed -r 's/tfsec version ([0-9]\.[0-9]+\.[0-9]+)/\1/' | grep -E -m 1 '[0-9]\.[0-9]+\.[0-9]+')" != "${TFSEC_VERSION}" ]]; then
-    echo "[ERROR] Error installing tfsec v${TFSEC_VERSION}"
-    echo "[ERROR] Please check the version is valid and try again"
-    return 1
-  fi
+  # With changes to tfsec moving to trivy this check doesn't work as expected and will need to be updated
+  # if [[ "$(tfsec --version | sed -r 's/tfsec version ([0-9]\.[0-9]+\.[0-9]+)/\1/' | grep -E -m 1 '[0-9]\.[0-9]+\.[0-9]+')" != "${TFSEC_VERSION}" ]]; then
+  #   echo "[ERROR] Error installing tfsec v${TFSEC_VERSION}"
+  #   echo "[ERROR] Please check the version is valid and try again"
+  #   return 1
+  # fi
   echo "[INFO] tfsec v${TFSEC_VERSION} installed"
 }
 

--- a/Shell/applets/terraform.applets
+++ b/Shell/applets/terraform.applets
@@ -42,129 +42,89 @@ terraform_install () {
 
 # Install Terraform for Linux
 tf_install_linux () {
-  # Terraform version passed from calling function
-  TF_VERSION="${1}"
-  # Check if Terraform is already installed and if the current version matches the version to be set
+  # If terraform is already installed report the version
   if command -v terraform &> /dev/null; then
-    if [[ "$(terraform version | sed -r 's/Terraform v([0-9]\.[0-9]+\.[0-9]+)/\1/' | grep -E '[0-9]\.[0-9]+\.[0-9]+' )" == "${TF_VERSION}" ]]; then
-      echo "[INFO] Terraform ${TF_VERSION} is already installed and is the latest version"
-      return 0
-    fi
+    echo "[INFO] Terraform $(terraform version | sed -r 's/Terraform v([0-9]\.[0-9]+\.[0-9]+)/\1/' | grep -E '[0-9]\.[0-9]+\.[0-9]+') is already installed"
   fi
-  echo "[INFO] Terraform is not installed or is not the latest version.  Installing Terraform ${TF_VERSION}"
-  # Setting the directory to download Terraform to
-  TF_DIR="${HOME}/.local/bin/tf/terraform-${TF_VERSION}"
-  # Check if the directory exists and if not create it
-  if [[ ! -d "${TF_DIR}" ]]; then
-    mkdir -p "${TF_DIR}"
+  # Test if the tfenv command is available and if it is exit as no further work needed
+  if command -v tfenv &> /dev/null; then
+    echo "[INFO] tfenv is already installed"
+    return 0
   fi
-  # Check the OS and set the download URL
-  if [[ "${OS}" == "Linux" ]]; then
-    TF_URL="https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip"
-  else
-    echo "[ERROR] Unsupported OS"
+  # If the tfenv command is not available then install it using the manual installation method
+  echo "[INFO] tfenv is not installed.  Installing tfenv"
+  git clone --depth=1 https://github.com/tfutils/tfenv.git ~/.tfenv
+  # If the git clone command fails then report an error and exit
+  if [[ $? -ne 0 ]]; then
+    echo "[ERROR] Error installing tfenv"
     return 1
   fi
-  # If the command unzip is not available then return an error - required for the install
-  if ! command -v unzip &> /dev/null; then
-    echo "[ERROR] Unzip is not installed"
+  # Add the tfenv bin directory to the PATH by sourcing the .pathVars file if it is not already in the PATH
+  if ! echo "${PATH}" | grep -q "${HOME}/.tfenv/bin"; then
+    echo "[INFO] Adding ${HOME}/.tfenv/bin to PATH"
+    source "${HOME}/.pathVars"
+  fi
+  # If the tfenv command is not available after adding the bin directory to the PATH then report an error and exit
+  if ! command -v tfenv &> /dev/null; then
+    echo "[ERROR] Error installing tfenv"
     return 1
   fi
-  # Check if the requested version is available in the directory and if not download it
-  if [[ ! -f "${TF_DIR}/terraform" ]]; then
-    echo "[INFO] Downloading Terraform-${TF_VERSION}"
-    curl -s -L "${TF_URL}" -o "${TF_DIR}/terraform.zip"
-    unzip -o "${TF_DIR}/terraform.zip" -d "${TF_DIR}"
-    chmod +x "${TF_DIR}/terraform"
-  fi
-  # Check that the version downloaded is available executable and if it report and error and exit
-  if [[ ! -x "${TF_DIR}/terraform" ]]; then
-    echo "[ERROR] Error downloading Terraform v${TF_VERSION}"
-    echo "[ERROR] Please check the version is valid and try again"
+  # If the tfenv command is available then install the latest version of Terraform
+  echo "[INFO] Installing latest version of Terraform"
+  tfenv install latest
+  # If the tfenv install command fails then report an error and exit
+  if [[ $? -ne 0 ]]; then
+    echo "[ERROR] Error installing Terraform"
     return 1
   fi
-  echo "[INFO] Terraform v${TF_VERSION} downloaded to ${TF_DIR}"
-  # Check if the current version of Terraform is a symlink and if so remove it
-  if [[ -L "$(command -v terraform)" ]]; then
-    echo "[INFO] Removing symlink to Terraform"
-    rm "$(command -v terraform)"
+  # If the tfenv install command is successful then set the latest version of Terraform as the global version
+  echo "[INFO] Setting Terraform v$(tfenv list-remote | grep -E -m 1 '[0-9]+\.[0-9]+\.[0-9]+' | tail -n 1) as the global version"
+  tfenv use latest
+  # If the tfenv use command fails then report an error and exit
+  if [[ $? -ne 0 ]]; then
+    echo "[ERROR] Error setting Terraform as the global version"
+    return 1
   fi
-  # If current version of Terraform is not a symlink then rename it to Terraform.old
-  if command -v terraform &> /dev/null; then
-    echo "[WARN] Renaming current version of Terraform (located at $(command -v terraform)) to Terraform.old"
-    mv "$(command -v terraform)" "$(command -v terraform).old"
-    echo "[WARN] If a permission error is reported then run the following command with sudo"
-    echo "sudo mv $(command -v terraform) $(command -v terraform).old"
-    echo "[WARN] If you wish to revert to the previous version of Terraform then run the following command:"
-    echo "mv $(command -v terraform).old $(command -v terraform)"
-  fi
-  # Create a symlink to the requested version of Terraform
-  echo "[INFO] Creating symlink to ${TF_VERSION} located at ${TF_DIR}/terraform"
-  ln -s "${TF_DIR}/terraform" "${HOME}/.local/bin/terraform"
+  # If the tfenv use command is successful then report the version of Terraform installed
+  echo "[INFO] Terraform $(terraform version | sed -r 's/Terraform v([0-9]\.[0-9]+\.[0-9]+)/\1/' | grep -E '[0-9]\.[0-9]+\.[0-9]+') installed"
   return 0
 }
 
 # Install Terraform for Mac
 tf_install_mac () {
-  # Terraform version passed from calling function
-  TF_VERSION="${1}"
-  # Check if Terraform is already installed and if the current version matches the version to be set
+  # If terraform is already installed report the version
   if command -v terraform &> /dev/null; then
-    if [[ "$(terraform version | sed -r 's/Terraform v([0-9]\.[0-9]+\.[0-9]+)/\1/' | grep -E '[0-9]\.[0-9]+\.[0-9]+')" == "${TF_VERSION}" ]]; then
-      echo "[INFO] Terraform ${TF_VERSION} is already installed and is the latest version"
-      return 0
-    fi
+    echo "[INFO] Terraform $(terraform version | sed -r 's/Terraform v([0-9]\.[0-9]+\.[0-9]+)/\1/' | grep -E '[0-9]\.[0-9]+\.[0-9]+') is already installed"
   fi
-  echo "[INFO] Terraform is not installed or is not the correct version.  Installing Terraform v${TF_VERSION}"
-  # Setting the directory to download Terraform to
-  TF_DIR="${HOME}/.local/bin/tf/terraform-${TF_VERSION}"
-  # Check if the directory exists and if not create it
-  if [[ ! -d "${TF_DIR}" ]]; then
-    mkdir -p "${TF_DIR}"
+  # If the tfenv command is not available then install it using Homebrew
+  if ! command -v tfenv &> /dev/null; then
+    echo "[INFO] tfenv is not installed.  Installing tfenv"
+    brew install tfenv
   fi
-  # Check the OS and set the download URL
-  if [[ "${OS}" == "Mac" ]]; then
-    TF_URL="https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_darwin_amd64.zip"
-  else
-    echo "[ERROR] Unsupported OS"
+  # If the tfenv command is not available after installing it then report an error and exit
+  if ! command -v tfenv &> /dev/null; then
+    echo "[ERROR] Error installing tfenv"
     return 1
   fi
-  # If the command unzip is not available then return an error - required for the install
-  if ! command -v unzip &> /dev/null; then
-    echo "[ERROR] Unzip is not installed"
+  # If the tfenv command is available then install the latest version of Terraform
+  echo "[INFO] Installing latest version of Terraform"
+  tfenv install latest
+  # If the tfenv install command fails then report an error and exit
+  if [[ $? -ne 0 ]]; then
+    echo "[ERROR] Error installing Terraform"
     return 1
   fi
-  # Check if the requested version is available in the directory and if not download it
-  if [[ ! -f "${TF_DIR}/terraform" ]]; then
-    echo "[INFO] Downloading Terraform-${TF_VERSION}"
-    curl -s -L "${TF_URL}" -o "${TF_DIR}/terraform.zip"
-    unzip -o "${TF_DIR}/terraform.zip" -d "${TF_DIR}"
-    chmod +x "${TF_DIR}/terraform"
-  fi
-  # Check that the version downloaded is available executable and if it report and error and exit
-  if [[ ! -x "${TF_DIR}/terraform" ]]; then
-    echo "[ERROR] Error downloading Terraform v${TF_VERSION}"
-    echo "[ERROR] Please check the version is valid and try again"
+  # If the tfenv install command is successful then set the latest version of Terraform as the global version
+  echo "[INFO] Setting Terraform v$(tfenv list-remote | grep -E -m 1 '[0-9]+\.[0-9]+\.[0-9]+' | tail -n 1) as the global version"
+  tfenv use latest
+  # If the tfenv use command fails then report an error and exit
+  if [[ $? -ne 0 ]]; then
+    echo "[ERROR] Error setting Terraform as the global version"
     return 1
   fi
-  echo "[INFO] Terrform v${TF_VERSION} downloaded to ${TF_DIR}"
-  # Check if the current version of Terraform is a symlink and if so remove it
-  if [[ -L "$(command -v terraform)" ]]; then
-    echo "Removing symlink to Terraform"
-    rm "$(command -v terraform)"
-  fi
-  # If current version of Terraform is not a symlink then rename it to Terraform.old
-  if command -v terraform &> /dev/null; then
-    echo "[WARN] Renaming current version of Terraform (located at $(command -v terraform)) to Terraform.old"
-    mv "$(command -v terraform)" "$(command -v terraform).old"
-    echo "[WARN] If a permission error is reported then run the following command with sudo"
-    echo "sudo mv $(command -v terraform) $(command -v terraform).old"
-    echo "[WARN] If you wish to revert to the previous version of Terraform then run the following command:"
-    echo "mv $(command -v terraform).old $(command -v terraform)"
-  fi
-  # Create a symlink to the requested version of Terraform
-  echo "[INFO] Creating symlink to ${TF_VERSION} located at ${TF_DIR}/terraform"
-  ln -s "${TF_DIR}/terraform" "${HOME}/.local/bin/terraform"
+  # If the tfenv use command is successful then report the version of Terraform installed
+  echo "[INFO] Terraform $(terraform version | sed -r 's/Terraform v([0-9]\.[0-9]+\.[0-9]+)/\1/' | grep -E '[0-9]\.[0-9]+\.[0-9]+') installed"
+  return 0
 }
 
 # Install TFLint for Linux
@@ -185,6 +145,11 @@ tflint_install_linux () {
     fi
   fi
   echo "[INFO] TFLint is not installed or is not the correct version.  Installing TFLint v${TFLINT_VERSION}"
+  # If the command unzip is not available then return an error - required for the install
+  if ! command -v unzip &> /dev/null; then
+    echo "[ERROR] Unzip is not installed - required for TFLint install"
+    return 1
+  fi
   # Setting the directory to download TFLint to
   TFLINT_DIR="${HOME}/.local/bin/tflint/tflint-${TFLINT_VERSION}"
   # Check if the directory exists and if not create it
@@ -302,6 +267,11 @@ tfsec_install_linux () {
   else
     go install github.com/aquasecurity/tfsec/cmd/tfsec@latest > /dev/null
   fi
+  # If ${HOME}/go/bin is not in the PATH then add it by sourcing the .pathVars file
+  if ! echo "${PATH}" | grep -q "${HOME}/go/bin"; then
+    echo "[INFO] Adding ${HOME}/go/bin to PATH"
+    source "${HOME}/.pathVars"
+  fi
   # Check if the version installed is the correct version and if not report an error
   if [[ "$(tfsec --version | sed -r 's/tfsec version ([0-9]\.[0-9]+\.[0-9]+)/\1/' | grep -E -m 1 '[0-9]\.[0-9]+\.[0-9]+')" != "${TFSEC_VERSION}" ]]; then
     echo "[ERROR] Error installing tfsec v${TFSEC_VERSION}"
@@ -354,6 +324,10 @@ tfsec_install_mac () {
 
 # Install terraform-docs for Linux
 terraform_docs_install_linux () {
+  # Issue or bug with v0.17.0 of terraform-docs, the go install doesn't produce the expected binary. For now marking this module as not working for Linux and exiting
+  echo "[ERROR] Automated installation of terraform-docs is not available for Linux.  Please install terraform-docs manually"
+  echo "[ERROR] For more information please refer to https://github.com/terraform-docs/terraform-docs#installation"
+  return 1
   # Referring to https://github.com/terraform-docs/terraform-docs#installation
   # Options for Linux are more limited than for macOS and either require homebrew for Linux or to use Go package management
   # Test if go/golang is not installed; if not then exit and refer user to the terraform-docs installation page
@@ -391,6 +365,11 @@ terraform_docs_install_linux () {
   else
     go install github.com/terraform-docs/terraform-docs/cmd/terraform-docs@latest > /dev/null
   fi
+  # If ${HOME}/go/bin is not in the PATH then add it by sourcing the .pathVars file
+  if ! echo "${PATH}" | grep -q "${HOME}/go/bin"; then
+    echo "[INFO] Adding ${HOME}/go/bin to PATH"
+    source "${HOME}/.pathVars"
+  fi
   # Check if the version installed is the correct version and if not report an error
   if [[ "$(terraform-docs --version | sed -r 's/v([0-9]\.[0-9]+\.[0-9]+)/\1/')" != "${TERRAFORM_DOCS_VERSION}" ]]; then
     echo "[ERROR] Error installing terraform-docs v${TERRAFORM_DOCS_VERSION}"
@@ -415,6 +394,31 @@ terraform_docs_install_mac () {
     if [[ "$(terraform-docs --version | sed -r 's/v([0-9]\.[0-9]+\.[0-9]+)/\1/')" == "${TERRAFORM_DOCS_VERSION}" ]]; then
       echo "[INFO] terraform-docs ${TERRAFORM_DOCS_VERSION} is already installed and is the latest version"
       return 0
+    fi
+  fi
+  echo "[INFO] terraform-docs is not installed or is not the correct version.  Installing terraform-docs v${TERRAFORM_DOCS_VERSION}"
+  # Use Homebrew to install terraform-docs
+  # Check if Homebrew is installed and if not report an error
+  if ! command -v brew &> /dev/null; then
+    echo "[ERROR] Homebrew is not installed.  Please install Homebrew and try again"
+    return 1
+  fi
+  # Check if terraform-docs is already installed, if not install it, if it is then upgrade it
+  if command -v terraform-docs &> /dev/null; then
+    echo "[INFO] Upgrading terraform-docs"
+    brew upgrade terraform-docs
+  else
+    echo "[INFO] Installing terraform-docs"
+    brew install terraform-docs
+  fi
+  # Check if terraform-docs is installed and if not report an error
+  if ! command -v terraform-docs &> /dev/null; then
+    echo "[ERROR] Error installing terraform-docs"
+    echo "[ERROR] Please check the version is valid and try again"
+    return 1
+  fi
+  echo "[INFO] terraform-docs ${TERRAFORM_DOCS_VERSION} installed"
+}     return 0
     fi
   fi
   echo "[INFO] terraform-docs is not installed or is not the correct version.  Installing terraform-docs v${TERRAFORM_DOCS_VERSION}"

--- a/Shell/applets/terraform.applets
+++ b/Shell/applets/terraform.applets
@@ -9,7 +9,7 @@
 # Define additional functions here
 
 # Update/Intstall Terraform for both Linux and mac
-terraform-install () {
+terraform_install () {
   if [[ -z ${OS} ]]; then
     echo "[WARN] OS variable is not set"
     return 1
@@ -22,16 +22,16 @@ terraform-install () {
     return 1
   fi
   if [[ ${OS} == "Linux" ]]; then
-    tf-linux-install "${TF_VERSION}"
-    tflint-linux-install
-    tfsec-linux-install
-    terraform-docs-linux-install
+    tf_install_linux "${TF_VERSION}"
+    tflint_install_linux
+    tfsec_install_linux
+    terraform_docs_install_linux
   fi
   if [[ ${OS} == "Mac" ]]; then
-    tf-mac-install "${TF_VERSION}"
-    tflint-mac-install
-    tfsec-mac-install
-    terraform-docs-mac-install
+    tf_install_mac "${TF_VERSION}"
+    tflint_install_mac
+    tfsec_install_mac
+    terraform_docs_install_mac
   fi
   # If OS is not set or is not Linux or Darwin then report an error
   if [[ ${OS} != "Linux" ]] && [[ ${OS} != "Mac" ]]; then
@@ -41,7 +41,7 @@ terraform-install () {
 }
 
 # Install Terraform for Linux
-tf-linux-install () {
+tf_install_linux () {
   # Terraform version passed from calling function
   TF_VERSION="${1}"
   # Check if Terraform is already installed and if the current version matches the version to be set
@@ -100,7 +100,7 @@ tf-linux-install () {
 }
 
 # Install Terraform for Mac
-tf-mac-install () {
+tf_install_mac () {
   # Terraform version passed from calling function
   TF_VERSION="${1}"
   # Check if Terraform is already installed and if the current version matches the version to be set
@@ -158,7 +158,7 @@ tf-mac-install () {
 }
 
 # Install TFLint for Linux
-tflint-linux-install () {
+tflint_install_linux () {
   # Referring to https://github.com/terraform-linters/tflint/blob/master/README.md
   # Check the latest available version of TFLint
   TFLINT_VERSION=$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep '"tag_name":' | sed -E 's/.+"v([^"]+)".+/\1/')
@@ -213,7 +213,7 @@ tflint-linux-install () {
 }
 
 # Install TFLint for macOS
-tflint-mac-install () {
+tflint_install_mac () {
   # Referring to https://github.com/terraform-linters/tflint/blob/master/README.md
   # Check the latest available version of TFLint
   TFLINT_VERSION=$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep '"tag_name":' | sed -E 's/.+"v([^"]+)".+/\1/')
@@ -254,7 +254,7 @@ tflint-mac-install () {
 }
 
 # Install tfsec for Linux
-tfsec-linux-install () {
+tfsec_install_linux () {
   # Referring to https://aquasecurity.github.io/tfsec/v1.28.1/guides/installation/
   # Options for Linux are more limited than for macOS and either require homebrew for Linux or to use Go package management
   # Test if go/golang is not installed; if not then exit and refer user to the tfsec installation page
@@ -280,7 +280,18 @@ tfsec-linux-install () {
   echo "[INFO] tfsec is not installed or is not the correct version.  Installing tfsec v${TFSEC_VERSION}"
   # Install tfsec using Go
   echo "[INFO] Installing tfsec using Go"
-  go install -u github.com/aquasecurity/tfsec/cmd/tfsec@latest
+  # If the environment variable GO_VERSION is not set then call the get_go_version function to set it
+  if [[ -z ${GO_VERSION} ]]; then
+    get_go_version
+  fi
+  GO_MAJOR_VERSION=$(echo "${GO_VERSION}" | cut -d. -f1)
+  GO_MINOR_VERSION=$(echo "${GO_VERSION}" | cut -d. -f2)
+  # If the combined major and minor version of Go is less than or equal to 1.17 then use the old method of installing tfsec with go get and if it is greater than 1.17 then use the new method of installing tfsec with go install
+  if [[ "${GO_MAJOR_VERSION}${GO_MINOR_VERSION}" -le 117 ]]; then
+    go get github.com/aquasecurity/tfsec/cmd/tfsec@latest
+  else
+    go install github.com/aquasecurity/tfsec/cmd/tfsec@latest
+  fi
   # Check if the version installed is the correct version and if not report an error
   if [[ "$(tfsec --version | sed -r 's/tfsec version ([0-9]\.[0-9]+\.[0-9]+)/\1/' | grep -E -m 1 '[0-9]\.[0-9]+\.[0-9]+')" != "${TFSEC_VERSION}" ]]; then
     echo "[ERROR] Error installing tfsec v${TFSEC_VERSION}"
@@ -291,7 +302,7 @@ tfsec-linux-install () {
 }
 
 # Install tfsec for Mac
-tfsec-mac-install () {
+tfsec_install_mac () {
   # Referring to https://aquasecurity.github.io/tfsec/v1.28.1/guides/installation/
   # Check the latest available version of tfsec
   TFSEC_VERSION=$(curl -s https://api.github.com/repos/aquasecurity/tfsec/releases/latest | grep '"tag_name":' | sed -E 's/.+"v([^"]+)".+/\1/')
@@ -332,7 +343,7 @@ tfsec-mac-install () {
 }
 
 # Install terraform-docs for Linux
-terraform-docs-linux-install () {
+terraform_docs_install_linux () {
   # Referring to https://github.com/terraform-docs/terraform-docs#installation
   # Options for Linux are more limited than for macOS and either require homebrew for Linux or to use Go package management
   # Test if go/golang is not installed; if not then exit and refer user to the terraform-docs installation page
@@ -358,7 +369,18 @@ terraform-docs-linux-install () {
   echo "[INFO] terraform-docs is not installed or is not the correct version.  Installing terraform-docs v${TERRAFORM_DOCS_VERSION}"
   # Install terraform-docs using Go
   echo "[INFO] Installing terraform-docs using Go"
-  go get -u github.com/terraform-docs/terraform-docs/cmd/terraform-docs@latest
+  # If the environment variable GO_VERSION is not set then call the get_go_version function to set it
+  if [[ -z ${GO_VERSION} ]]; then
+    get_go_version
+  fi
+  GO_MAJOR_VERSION=$(echo "${GO_VERSION}" | cut -d. -f1)
+  GO_MINOR_VERSION=$(echo "${GO_VERSION}" | cut -d. -f2)
+  # If the combined major and minor version of Go is less than or equal to 1.17 then use the old method of installing terraform-docs with go get and if it is greater than 1.17 then use the new method of installing terraform-docs with go install
+  if [[ "${GO_MAJOR_VERSION}${GO_MINOR_VERSION}" -le 117 ]]; then
+    go get github.com/terraform-docs/terraform-docs/cmd/terraform-docs@latest
+  else
+    go install github.com/terraform-docs/terraform-docs/cmd/terraform-docs@latest
+  fi
   # Check if the version installed is the correct version and if not report an error
   if [[ "$(terraform-docs --version | sed -r 's/v([0-9]\.[0-9]+\.[0-9]+)/\1/')" != "${TERRAFORM_DOCS_VERSION}" ]]; then
     echo "[ERROR] Error installing terraform-docs v${TERRAFORM_DOCS_VERSION}"
@@ -369,7 +391,7 @@ terraform-docs-linux-install () {
 }
 
 # Install terraform-docs for Mac
-terraform-docs-mac-install () {
+terraform_docs_install_mac () {
   # Referring to https://github.com/terraform-docs/terraform-docs#installation
   # Check the latest available version of terraform-docs
   TERRAFORM_DOCS_VERSION=$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep '"tag_name":' | sed -E 's/.+"v([^"]+)".+/\1/')

--- a/Shell/applets/terraform.applets
+++ b/Shell/applets/terraform.applets
@@ -267,10 +267,10 @@ tfsec_install_linux () {
   else
     go install github.com/aquasecurity/tfsec/cmd/tfsec@latest > /dev/null
   fi
-  # If ${HOME}/go/bin is not in the PATH then add it by sourcing the .pathVars file
-  if ! echo "${PATH}" | grep -q "${HOME}/go/bin"; then
+  # If ${HOME}/go/bin is not in the PATH then add it
+  if [[ ! ":$PATH:" == *":${HOME}/go/bin:"* ]]; then
     echo "[INFO] Adding ${HOME}/go/bin to PATH"
-    source "${HOME}/.pathVars"
+    PATH="${HOME}/go/bin:${PATH}"
   fi
   # Check if the version installed is the correct version and if not report an error
   if [[ "$(tfsec --version | sed -r 's/tfsec version ([0-9]\.[0-9]+\.[0-9]+)/\1/' | grep -E -m 1 '[0-9]\.[0-9]+\.[0-9]+')" != "${TFSEC_VERSION}" ]]; then


### PR DESCRIPTION
- Switch terraform installer to install tfenv rather than reinvent the wheel
- Go based installer for tfsec updated to use `go install` for Go 1.18 and higher
  - Maintaining `go get` for 1.17 and lower
- Did the same for terraform-dcos but the installer for that seems broken and doesn't create the binary in GOPATH/bin so disabled
- Fixed and improved logs and PATH var updates