### PR TITLE
Including provision for machine local inclusions in dot files

### DIFF
--- a/Shell/.profile
+++ b/Shell/.profile
@@ -84,3 +84,8 @@ fi
 if [[ -f ~/.tasks ]]; then
 	source ~/.tasks
 fi
+
+# Adding machine specific configuration
+if [[ -f ~/.machine_local ]]; then
+  source ~/.machine_local
+fi

--- a/Shell/machine_local.template
+++ b/Shell/machine_local.template
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Path: .machine_local
+# Purpose: Local machine specific configurations.
+# Use: Add aliases to this file and they will be sourced by .zshrc
+


### PR DESCRIPTION
- Fixed a  bug in install if the current dir was not the repo dir
- Added a template machine local file
- Included logic in all file copy to copy machine local template to local machine
  - Copying not linking to avoid syncing back into git/repo
- Included machine local file in profile sourcing