### PR TITLE
Fixing issues with git-remove-untracked

### DIFF
--- a/Git/.gitconfig
+++ b/Git/.gitconfig
@@ -4,6 +4,9 @@
 	editor = code --wait
 	#editor = code-insiders --wait
 
+[helper]
+	credential = store
+
 [init]
 	defaultBranch = main
 

--- a/Shell/.alias
+++ b/Shell/.alias
@@ -85,6 +85,11 @@ if command -v git &> /dev/null; then
   alias gst="git status"
   alias gpl="git pull"
   alias gps="git push"
+  # If the git_cleanup function is defined, set an alias for it
+  if declare -f git_cleanup &> /dev/null; then
+    alias gitcleanup="git_cleanup"
+    alias git-remove-untracked="git_cleanup"
+  fi
 fi
 
 # If the github cli and copilot extension are installed, set alias for copilot

--- a/Shell/applets/general.applets
+++ b/Shell/applets/general.applets
@@ -13,8 +13,16 @@ cheat(){
     curl "cheat.sh/$1"
 }
 
-git-remove-untracked() {
-  git fetch --prune && git branch -r | awk "{print \$1}" | grep -E -v -f /dev/fd/0 <(git branch -vv | grep origin) | awk "{print \$1}" | xargs git branch -D
+# Cleanup removed branches in git
+function git_cleanup() {
+    # Fetch updates
+    git fetch -p
+
+    # Remove local branches that have been deleted on the remote
+    for branch in $(git branch -vv | grep ': gone]' | awk '{print $1}'); do
+        echo "Deleting branch $branch"
+        git branch -D "$branch"
+    done
 }
 
 # Show SSH Tunnel


### PR DESCRIPTION
- Issues with the original git-remove-untracked since moving to a function.
- Updated with new git_cleanup function
  - With assistance from copilot
  - Simplified process
  - Safer with unpublished branches
- Added an alias to use old git-remove-untracked for anyone still using it